### PR TITLE
docs: Add package repo link to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .*.swp
 *~
 *.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Packages Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square)](https://cloudsmith.io/~opennms/repos/common/packages/)
+
 # Advanced IP Address String Matching for PostgreSQL
 
 While PostgreSQL has native support for IP addresses, there are use


### PR DESCRIPTION
I got this suggestion and I think this is a good idea to link the package repository in the projects README page.

## Reviewer Hint

We need to clarify first where we want to publish the RPM/DEB packages.