### PR TITLE
chore: Remove PostgreSQL 13

### DIFF
--- a/.github/workflows/iplike-build.yaml
+++ b/.github/workflows/iplike-build.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        pg_version: [ 13, 14, 15, 16, 17, 18 ]
+        pg_version: [ 14, 15, 16, 17, 18 ]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
PostgreSQL 13 is EOL since November 2025 and there won't be new versions for it. See https://www.postgresql.org/support/versioning/